### PR TITLE
Fix clang-format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,4 +19,4 @@ jobs:
         sudo apt-get install `apt-cache search -n clang-format-[0-9]+ | sort -V -r | sed -n '1{s/^\([^ ]*\).*/\1/p}'`
     - name: apply formatter
       run: |
-        clang-format-18 --dry-run --Werror $(find . -name "*.hpp" -or -name "*.cpp")
+        `apt-cache search -n clang-format-[0-9]+ | sort -V -r | sed -n '1{s/^\([^ ]*\).*/\1/p}'` --dry-run --Werror $(find . -name "*.hpp" -or -name "*.cpp")


### PR DESCRIPTION
<!--
>>> タイトルはある程度内容に沿っていればなんでもいいです。自由につけてください。
>>>
>>> 例
>>> - fix #61
>>>   - https://github.com/luzhiled1333/comp-library/pull/62
>>> - implement bit operations
>>>   - https://github.com/luzhiled1333/comp-library/pull/105
-->

# 概要 / Overview
clang-format のバージョンが上がると動かなくなるバグがあるので修正をします


# 関連 issue, PR / Related issues, PRs
<!--
>>> 以下に箇条書きの形式で関連する issue, PR の番号を記載してください。
>>>
>>> 例
>>> - #5
>>>
>>> 必要なければ消しても大丈夫です
-->

- #


# TODO
<!--
>>> この項目は必要がなけれれば削除してください。
>>> 項目が不足している場合は適宜追加していただいても構いません。
-->

- [ ] 実装
- [ ] ドキュメント作成
- [ ] unit-test
- [ ] verify

# CI 関連項目
<!--
>>> 以下はリポジトリ内であればどこでも実行できるようになっていると思います。
>>> 作業用のメモとして残しておいてください。
-->

## verify-check / verify
```sh
(cd $(git rev-parse --show-toplevel) && oj-verify all)
```

## clang-format
```sh
(cd $(git rev-parse --show-toplevel) && clang-format -i $(find src/ test/ unit-test/ -name "*.hpp" -or -name "*.cpp"))
```
